### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202012-v0.2.7
+ref=202012.3.0.1


### PR DESCRIPTION
Release Notes for Cisco Platforms:
- Updated mtd-utils.mk and pyudev.mk for build failures

How I did it
- Update platform version to 202012.3.0.1
